### PR TITLE
Begin/Rescue for IMDB invalid dates

### DIFF
--- a/lib/filmbuff/title.rb
+++ b/lib/filmbuff/title.rb
@@ -50,8 +50,12 @@ class FilmBuff
       @genres = imdb_hash['genres'] || []
 
       if imdb_hash['release_date']
-        @release_date = Date.strptime(imdb_hash['release_date']['normal'],
+        begin
+          @release_date = Date.strptime(imdb_hash['release_date']['normal'],
                                       '%Y-%m-%d')
+        rescue
+          @release_date = imdb_hash['release_date']['normal']
+        end                              
       end
     end
   end


### PR DESCRIPTION
Needs a begin/rescue block for IMDB dates that are invalid. Fall back to date given from API instead of re-formatting.
